### PR TITLE
gzipdb_out support and updated template

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,0 +1,12 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# https://docs.puppet.com/guides/tests_smoke.html
+#
+include ::aide

--- a/examples/site.pp
+++ b/examples/site.pp
@@ -1,0 +1,17 @@
+node default {
+  class { 'aide':
+    minute => 0,
+  }
+  aide::rule { 'MyRule':
+    rules => [ 'p', 'sha256'],
+  }
+  aide::watch { '/etc':
+    path  => '/etc',
+    rules => 'MyRule'
+  }
+  aide::watch { '/boot':
+    path  => '/boot',
+    rules => 'MyRule'
+  }
+
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,4 +13,17 @@ class aide::config inherits aide {
     order   => 01,
     content => template( 'aide/aide.conf.erb')
   }
+
+  concat::fragment { 'rule_header':
+    target  => 'aide.conf',
+    order   => '02',
+    content => "# User defined rules\n",
+  }
+
+  concat::fragment { 'watch_header':
+    target  => 'aide.conf',
+    order   => '49',
+    content => "\n# Files and directories to scan\n",
+  }
+
 }

--- a/manifests/firstrun.pp
+++ b/manifests/firstrun.pp
@@ -21,7 +21,7 @@ class aide::firstrun inherits aide {
     mode    => '0600',
     require => Exec['install aide db']
   }
-  file { '/var/lib/aide/aide.db.new.gz':
+  file { $::aide::db_temp_path:
     owner   => root,
     group   => root,
     mode    => '0600',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,8 @@ class aide (
     $conf_path    = $aide::params::conf_path,
     $db_path      = $aide::params::db_path,
     $db_temp_path = $aide::params::db_temp_path,
-    $minute       = $aide::params::minute
+    $minute       = $aide::params::minute,
+    $gzip_dbout   = $aide::params::gzip_dbout,
   ) inherits aide::params {
 
   anchor { 'aide::begin': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,8 +2,9 @@
 class aide::params {
   $package      = 'aide'
   $version      = latest
-  $db_path      = '/var/lib/aide/aide.db.gz'
+  $db_path      = '/var/lib/aide/aide.db'
   $db_temp_path = '/var/lib/aide/aide.db.new'
+  $gzip_dbout   = 'no'
   $minute       = 0
 
   case $::osfamily {

--- a/templates/aide.conf.erb
+++ b/templates/aide.conf.erb
@@ -5,6 +5,9 @@ database=file:<%= @db_path %>
 database_out=file:<%= @db_temp_path %>
 database_new=file:<%= @db_temp_path %>
 
+# gzip output to the database?
+gzip_dbout=<%= @gzip_dbout %>
+
 # Rule predefined types:
 #p:      permissions
 #i:      inode:

--- a/templates/aide.conf.erb
+++ b/templates/aide.conf.erb
@@ -1,3 +1,32 @@
+# Configuration file for AIDE.
+
+# Database configuration
 database=file:<%= @db_path %>
 database_out=file:<%= @db_temp_path %>
 database_new=file:<%= @db_temp_path %>
+
+# Rule predefined types:
+#p:      permissions
+#i:      inode:
+#n:      number of links
+#u:      user
+#g:      group
+#s:      size
+#b:      block count
+#m:      mtime
+#a:      atime
+#c:      ctime
+#S:      check for growing size
+#acl:    Access Control Lists
+#selinux:SELinux security context
+#xattrs: Extended file attributes
+#md5:    md5 checksum
+#sha1:   sha1 checksum
+#sha256: sha256 checksum
+
+# Rule predefined aliases
+#R:             p+i+n+u+g+s+m+c+acl+selinux+xattrs+md5
+#L:             p+i+n+u+g+acl+selinux+xattrs
+#E:             Empty group
+#>:             Growing logfile p+u+g+i+n+S+acl+selinux+xattrs
+


### PR DESCRIPTION
This PR adds an option to specify if the output DB should be compressed, as well as adding extra information to the aide.conf template that makes it easier to understand what options are available in aide and header lines for the rule and watches.
Some example manifests have also been added